### PR TITLE
Update Estimate_W.py

### DIFF
--- a/Estimate_W.py
+++ b/Estimate_W.py
@@ -97,6 +97,9 @@ def Wfast(img,nstains,lamb,num_patches,patchsize,level,background_correction=Fal
 		suppress_stdout(out)
 
 		WS=np.array(WS)
+		# Ensure stain columns are sorted correct before taking median
+		for i in range(len(WS)):
+			WS[i] = W_sort(WS[i])
 
 		if WS.shape[0]==1:
 			Wsource=WS[0,:3,:]


### PR DESCRIPTION
Taking median of W matrix of patches before sorting by stain gets incorrect median. The code does sort down the line, but medians are already taken before it.

Doing this results in much better W matrices. For HE stain, roughly the H Red value to E red value is approx. ratio of 5:1.9 . Without this fix, we see at times, the H and E red values are almost similar ~0.3 and result is H stain creates very dark pink backgrounds in stain separation and purplish backgrounds in normalization.